### PR TITLE
Fix Test

### DIFF
--- a/README_test.md
+++ b/README_test.md
@@ -1,0 +1,43 @@
+# Testing
+
+A unit test is required. 
+The test has a minimum 70% coverage limit.
+If the coverage is less than 70%, the push request will not be accepted.
+
+## Mock Record
+
+To mock the configuration record the `MockRecord` from `plugin_dev.test_base` 
+  is used.
+It is class subclass of `Record` from [Keeper Secrets Manager SDK](https://github.com/Keeper-Security/secrets-manager/blob/a95f3a01e55b9552805e65d365d33227ae51fe57/sdk/python/core/keeper_secrets_manager_core/dto/dtos.py#L23).
+
+
+```python
+from __future__ import annotations
+import unittest
+from .my_plugin import SaasPlugin
+from kdnrm.secret import Secret
+from kdnrm.saas_type import SaasUser
+from plugin_dev.test_base import MockRecord
+from typing import Optional
+
+
+class MyPluginTest(unittest.TestCase):
+
+    @staticmethod
+    def plugin(prior_password: Optional[Secret] = None):
+
+        user = SaasUser(
+            username=Secret("jdoe"),
+            new_password=Secret("NewPassword123"),
+            prior_password=prior_password
+        )
+
+        config_record = MockRecord(
+            custom=[
+                {'type': 'text', 'label': 'My Custom Field', 'value': ['Hello']},
+                {'type': 'text', 'label': 'Another Custom FIeld', 'value': ['There']},
+            ]
+        )
+
+        return SaasPlugin(user=user, config_record=config_record)
+```

--- a/integrations/aws_cognito/aws_cognito.py
+++ b/integrations/aws_cognito/aws_cognito.py
@@ -22,8 +22,6 @@ class SaasPlugin(SaasPluginBase):
 
     def __init__(self, user: SaasUser, config_record: Record, provider_config=None, force_fail=False):
         super().__init__(user, config_record, provider_config, force_fail)
-        self.user = user
-        self.config_record = config_record
         self._client = None
     
     @classmethod

--- a/integrations/aws_cognito/aws_cognito_test.py
+++ b/integrations/aws_cognito/aws_cognito_test.py
@@ -7,6 +7,7 @@ from kdnrm.log import Log
 from kdnrm.saas_type import SaasUser, AwsConfig
 from kdnrm.exceptions import SaasException
 from botocore.exceptions import ClientError
+from plugin_dev.test_base import MockRecord
 from typing import Optional, Any, List
 
 
@@ -36,23 +37,15 @@ class AwsCognitoTest(unittest.TestCase):
             prior_password=prior_password
         )
 
-        config_record = MagicMock()
-        config_record.dict = {
-            'fields': [],
-            'custom': [
+        config_record = MockRecord(
+            custom=[
                 {'type': 'secret', 'label': 'User Pool ID', 'value': [field_values[0]]},
                 {'type': 'text', 'label': 'AWS Access Key ID', 'value': [field_values[1]]},
                 {'type': 'secret', 'label': 'AWS Secret Access Key', 'value': [field_values[2]]},
                 {'type': 'text', 'label': 'AWS Region', 'value': [field_values[3]]},
 
             ]
-        }
-        config_record.title = 'AWS Cognito Config'
-        config_record.type = 'login'
-        config_record.uid = 'fakeUid'
-
-        # The param checker does not like MagicMock.
-        config_record.get_custom_field_value.side_effect = field_values
+        )
 
         return SaasPlugin(user=user, config_record=config_record, provider_config=provider_config)
 

--- a/integrations/cisco_apic/README.md
+++ b/integrations/cisco_apic/README.md
@@ -17,7 +17,7 @@ In order to use the post-rotation script, you will need the following prerequisi
 
 ## Steps to Test CISCO APIC 
 ### 1. Login to Cisco Sandbox: 
-- Go to the [Cisco DevNet Sandbox](hhttps://developer.cisco.com/)
+- Go to the [Cisco DevNet Sandbox](https://developer.cisco.com/)
 - Log in with your Cisco account credentials.
 
     <img src="images/login_account.png" width="350" alt="login_account">

--- a/integrations/cisco_apic/cisco_apic_test.py
+++ b/integrations/cisco_apic/cisco_apic_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
+from plugin_dev.test_base import MockRecord
 from .cisco_apic import SaasPlugin
 from kdnrm.secret import Secret
 from kdnrm.log import Log
@@ -27,28 +28,14 @@ class CiscoApicTest(unittest.TestCase):
             prior_password=prior_password
         )
 
-        config_record = MagicMock()
-        config_record.dict = {
-            'fields': [
-                {"type": "fileRef", "value": ["FILE_UID"]}
-            ],
-            'custom': [
+        config_record = MockRecord(
+            custom=[
                 {'type': 'text', 'label': 'Admin Name', 'value': ['ADMIN']},
                 {'type': 'secret', 'label': 'Admin Password', 'value': ['PASSWORD']},
+                {'type': 'secret', 'label': 'Certificate', 'value': ['BEGIN CERTIFICATE']},
                 {'type': 'url', 'label': 'URL', 'value': ['https://apic.localhost']},
             ]
-        }
-        config_record.title = 'APIC Config'
-        config_record.type = 'login'
-        config_record.uid = 'fakeUid'
-
-        # The param checker does not like MagicMock.
-        config_record.get_custom_field_value.side_effect = [
-            "ADMIN",
-            "PASSWORD",
-            "https://apic.localhost"
-        ]
-        config_record.download_file_by_title.return_value = "PEM_DATA"
+        )
 
         return SaasPlugin(user=user, config_record=config_record)
 
@@ -106,29 +93,13 @@ class CiscoApicTest(unittest.TestCase):
             new_password=Secret("NewPassword123")
         )
 
-        config_record = MagicMock()
-        config_record.dict = {
-            'fields': [
-                {"type": "fileRef", "value": ["FILE_UID"]}
-            ],
-            'custom': [
+        config_record = MockRecord(
+            custom=[
                 {'type': 'secret', 'label': 'Admin Password', 'value': ['PASSWORD']},
+                {'type': 'secret', 'label': 'Certificate', 'value': ['BEGIN CERTIFICATE']},
                 {'type': 'url', 'label': 'URL', 'value': ['https://apic.localhost']},
             ]
-        }
-        config_record.title = 'APIC Config'
-        config_record.type = 'login'
-        config_record.uid = 'fakeUid'
-
-        # The param checker does not like MagicMock.
-        config_record.get_custom_field_value.side_effect = [
-            # Missing for `label`, `code` and `id`
-            # Need three Nones to mock a missing field
-            None,
-            "PASSWORD",
-            "https://apic.localhost"
-        ]
-        config_record.download_file_by_title.return_value = "PEM_DATA"
+        )
 
         try:
             SaasPlugin(user=user, config_record=config_record)
@@ -149,27 +120,13 @@ class CiscoApicTest(unittest.TestCase):
             new_password=Secret("NewPassword123")
         )
 
-        config_record = MagicMock()
-        config_record.dict = {
-            'fields': [
-                {"type": "fileRef", "value": ["FILE_UID"]}
-            ],
-            'custom': [
+        config_record = MockRecord(
+            custom=[
                 {'type': 'text', 'label': 'Admin Name', 'value': ['ADMIN']},
+                {'type': 'secret', 'label': 'Certificate', 'value': ['BEGIN CERTIFICATE']},
                 {'type': 'url', 'label': 'URL', 'value': ['https://apic.localhost']},
             ]
-        }
-        config_record.title = 'APIC Config'
-        config_record.type = 'login'
-        config_record.uid = 'fakeUid'
-
-        # The param checker does not like MagicMock.
-        config_record.get_custom_field_value.side_effect = [
-            "ADMIN",
-            None,
-            "https://apic.localhost"
-        ]
-        config_record.download_file_by_title.return_value = "PEM_DATA"
+        )
 
         try:
             SaasPlugin(user=user, config_record=config_record)
@@ -190,28 +147,13 @@ class CiscoApicTest(unittest.TestCase):
             new_password=Secret("NewPassword123")
         )
 
-        config_record = MagicMock()
-        config_record.dict = {
-            'fields': [
-                {"type": "fileRef", "value": ["FILE_UID"]}
-            ],
-            'custom': [
+        config_record = MockRecord(
+            custom=[
                 {'type': 'text', 'label': 'Admin Name', 'value': ['ADMIN']},
                 {'type': 'secret', 'label': 'Admin Password', 'value': ['PASSWORD']},
-
+                {'type': 'secret', 'label': 'Certificate', 'value': ['BEGIN CERTIFICATE']},
             ]
-        }
-        config_record.title = 'APIC Config'
-        config_record.type = 'login'
-        config_record.uid = 'fakeUid'
-
-        # The param checker does not like MagicMock.
-        config_record.get_custom_field_value.side_effect = [
-            "ADMIN",
-            "PASSWORD",
-            None
-        ]
-        config_record.download_file_by_title.return_value = "PEM_DATA"
+        )
 
         try:
             SaasPlugin(user=user, config_record=config_record)
@@ -232,28 +174,14 @@ class CiscoApicTest(unittest.TestCase):
             new_password=Secret("NewPassword123")
         )
 
-        config_record = MagicMock()
-        config_record.dict = {
-            'fields': [
-                {"type": "fileRef", "value": ["FILE_UID"]}
-            ],
-            'custom': [
+        config_record = MockRecord(
+            custom=[
                 {'type': 'text', 'label': 'Admin Name', 'value': ['ADMIN']},
                 {'type': 'secret', 'label': 'Admin Password', 'value': ['PASSWORD']},
-                {'type': 'url', 'label': 'URL', 'value': ['bad_url']},
+                {'type': 'secret', 'label': 'Certificate', 'value': ['BEGIN CERTIFICATE']},
+                {'type': 'url', 'label': 'URL', 'value': ['ftp://apic.localhost']},
             ]
-        }
-        config_record.title = 'APIC Config'
-        config_record.type = 'login'
-        config_record.uid = 'fakeUid'
-
-        # The param checker does not like MagicMock.
-        config_record.get_custom_field_value.side_effect = [
-            "ADMIN",
-            "PASSWORD",
-            "bad_url"
-        ]
-        config_record.download_file_by_title.return_value = "PEM_DATA"
+        )
 
         try:
             SaasPlugin(user=user, config_record=config_record)
@@ -261,49 +189,6 @@ class CiscoApicTest(unittest.TestCase):
         except SaasException as err:
             if "does not appears to be a URL" not in str(err):
                 self.fail("did not message containing 'does not appears to be a URL'")
-        except Exception as err:
-            self.fail(f"got wrong exception: {err}")
-
-    def test_missing_file_ref(self):
-        """
-        Missing the "fileRef" field.
-
-        All records have "fileRef" so this is almost impossible, but Commander
-        might allow you to do this.
-        """
-
-        user = SaasUser(
-            username=Secret("jdoe"),
-            new_password=Secret("NewPassword123")
-        )
-
-        config_record = MagicMock()
-        config_record.dict = {
-            'custom': [
-                {'type': 'text', 'label': 'Admin Name', 'value': ['ADMIN']},
-                {'type': 'secret', 'label': 'Admin Password', 'value': ['PASSWORD']},
-                {'type': 'url', 'label': 'URL', 'value': ['https://apic.localhost']},
-            ]
-        }
-        config_record.title = 'APIC Config'
-        config_record.type = 'login'
-        config_record.uid = 'fakeUid'
-
-        # The param checker does not like MagicMock.
-        config_record.get_custom_field_value.side_effect = [
-            "ADMIN",
-            "PASSWORD",
-            "https://apic.localhost"
-        ]
-        config_record.download_file_by_title.return_value = None
-
-        try:
-            plugin = SaasPlugin(user=user, config_record=config_record)
-            plugin.change_password()
-            raise Exception("should have failed")
-        except SaasException as err:
-            if "Missing 'file ref'" not in str(err):
-                self.fail("did not message containing 'Missing 'file ref''")
         except Exception as err:
             self.fail(f"got wrong exception: {err}")
 
@@ -474,5 +359,3 @@ class CiscoApicTest(unittest.TestCase):
                     self.fail("did not message containing 'Failed to roll back password'")
             except Exception as err:
                 self.fail(f"got wrong exception: {err}")
-
-

--- a/integrations/dummy/dummy_test.py
+++ b/integrations/dummy/dummy_test.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 import unittest
-from unittest.mock import MagicMock
 from .dummy import SaasPlugin
 from kdnrm.secret import Secret
 from kdnrm.log import Log
 from kdnrm.saas_type import SaasUser
+from plugin_dev.test_base import MockRecord
 from typing import Optional
 
 
@@ -24,22 +24,12 @@ class DummyTest(unittest.TestCase):
             prior_password=prior_password
         )
 
-        config_record = MagicMock()
-        config_record.dict = {
-            'custom': [
+        config_record = MockRecord(
+            custom=[
                 {'type': 'text', 'label': 'Dummy Text', 'value': ['SOME TEXT']},
                 {'type': 'text', 'label': 'Font Type', 'value': ['bulbhead']},
             ]
-        }
-        config_record.title = 'Dummy Config'
-        config_record.type = 'login'
-        config_record.uid = 'fakeUid'
-
-        # The param checker does not like MagicMock.
-        config_record.get_custom_field_value.side_effect = [
-            "SOME TEXT",
-            "bulbhead"
-        ]
+        )
 
         return SaasPlugin(user=user, config_record=config_record)
 

--- a/kdnrm/saas_plugins/__init__.py
+++ b/kdnrm/saas_plugins/__init__.py
@@ -36,23 +36,15 @@ class SaasPluginBase:
         for item in self.__class__.config_schema():
             value = None
 
-            # Try to find the value.
-            # Pre-i18n it will match the label.
-            # Post-i18n it will match i18n code.
-            # And try the ID, just in case
-            for key in ["label", "id"]:
-                key_value = getattr(item, key)
-                if key_value is None:
-                    continue
-                try:
-                    value = config_record.get_custom_field_value(key_value, single=True)
-                    if value is not None:
-                        value = value.strip()
-                    if value == "":
-                        value = None
-                    break
-                except (Exception,):
-                    pass
+            # For now, we use the label
+            try:
+                value = config_record.get_custom_field_value(item.label, single=True)
+                if value is not None:
+                    value = value.strip()
+                if value == "":
+                    value = None
+            except (Exception,):
+                pass
 
             # If the value is None, set it to the default value.
             if value is None:

--- a/plugin_dev/test_base.py
+++ b/plugin_dev/test_base.py
@@ -3,8 +3,37 @@ import logging
 import os
 import subprocess
 import ast
+from keeper_secrets_manager_core.dto.dtos import Record
+from keeper_secrets_manager_core.utils import generate_uid_bytes
 from colorama import Fore, Style
 from typing import List, Dict, Any, Optional
+
+
+class MockRecord(Record):
+
+    # Don't call super
+    def __init__(self,
+                 title: Optional[str] = "SaaS Config",
+                 record_type: str = "login",
+                 uid: Optional[str] = None,
+                 fields: Optional[List[dict]] = None,
+                 custom: Optional[List[dict]] = None):
+
+        if uid is None:
+            uid = generate_uid_bytes()
+
+        self.uid = uid
+        self.title = title
+        self.type = record_type
+        self.files = []
+
+        if fields is None:
+            fields = []
+
+        self.dict = {
+            "fields": fields,
+            "custom": custom
+        }
 
 
 class WorkflowBase:


### PR DESCRIPTION
Added MockRecord.
The called to `get_custom_field_value` doesn't exists, and the method would need to be mocked.
This solution uses KSM's Record and just changes how the instance is created.
Most of KSM record's method should work with thei MockRecord version.