### PR TITLE
Update Cisco APIC

### DIFF
--- a/integrations/aws_cognito/README.md
+++ b/integrations/aws_cognito/README.md
@@ -74,11 +74,10 @@ Using the `pam action saas config` command with `--list` flag will show all plug
 My Vault> pam action saas config -g <GATEWAY UID> --list
 
 Available SaaS Plugins
- * AWS Cognito (Catalog)
- * Cisco APIC (Catalog)
-...
- * REST (Builtin)
- * Snowflake (Builtin)
+ * Custom One (Custom) - Plugin has no description.
+ * AWS Cognito (Catalog) - Change a users password in AWS Cognito.
+ ...
+ * Snowflake (Builtin) - For Snowflake, rotate the password for a user.
 ```
 
 If **AWS Cognito** is in the list, you can use this plugin.

--- a/integrations/aws_cognito/aws_cognito_test.py
+++ b/integrations/aws_cognito/aws_cognito_test.py
@@ -43,7 +43,6 @@ class AwsCognitoTest(unittest.TestCase):
                 {'type': 'text', 'label': 'AWS Access Key ID', 'value': [field_values[1]]},
                 {'type': 'secret', 'label': 'AWS Secret Access Key', 'value': [field_values[2]]},
                 {'type': 'text', 'label': 'AWS Region', 'value': [field_values[3]]},
-
             ]
         )
 

--- a/integrations/cisco_apic/README.md
+++ b/integrations/cisco_apic/README.md
@@ -18,6 +18,9 @@ It's a software-defined networking (SDN) controller that manages and enforces po
 
 
 
+
+
+
 ## Commander
 
 ### Create SaaS Configuration Record
@@ -25,26 +28,23 @@ It's a software-defined networking (SDN) controller that manages and enforces po
 In Commander, the `pam action saas config` command is used to create a SaaS Configuration record.
 This record currently is a **Login** record where the custom fields are used for settings.
 
-First check if the **AWS Cognito** plugin is available.
+First check if the **Cisco APIC** plugin is available.
 Using the `pam action saas config` command with `--list` flag will show all plugins available to your Keeper Gateway.
 
 ```
 My Vault> pam action saas config -g <GATEWAY UID> --list
 
 Available SaaS Plugins
- * AWS Cognito (Catalog)
- * Cisco APIC (Catalog)
-...
- * REST (Builtin)
- * Snowflake (Builtin)
+ * Cisco APIC (Catalog) - Change a user password in Cisco APIC.
+ ...
 ```
 
-If **AWS Cognito** is in the list, you can use this plugin.
+If **Cisco APIC** is in the list, you can use this plugin.
 
 Before creating the SaaS Configuration Record, you can get a preview of fields you will be prompted for values.
-Next use `pam action saas config`, with `--info` flag and `-p "AWS Cognito"`, to get information about this plugin.
+Next use `pam action saas config`, with `--info` flag and `-p "Cisco APIC"`, to get information about this plugin.
 ```
-My Vault> pam action saas config -g <GATEWAY> -p "AWS Cognito" --info
+My Vault> pam action saas config -g <GATEWAY> -p "Cisco APIC" --info
 
 AWS Cognito
   Type: catalog

--- a/integrations/cisco_apic/README_development.md
+++ b/integrations/cisco_apic/README_development.md
@@ -5,7 +5,7 @@ This user guide covers the post-rotation script for the Keeper Security / CISCO 
 
 ## CISCO APIC
 The [Cisco Application Policy Infrastructure Controller (APIC)](https://www.cisco.com/c/en_in/products/cloud-systems-management/application-policy-infrastructure-controller-apic/index.html) is the central control point for Cisco's Application Centric Infrastructure (ACI) solution. It's a software-defined networking (SDN) controller that manages and enforces policies, provides visibility and control over network resources, and orchestrates network provisioning. 
-
+https://www.cisco.com/c/en/us/td/docs/dcn/aci/apic/all/apic-rest-api-configuration-guide/cisco-apic-rest-api-configuration-guide-42x-and-later/m_using_the_rest_api.html
 ## Pre-requisites
 In order to use the post-rotation script, you will need the following prerequisites:
 
@@ -82,3 +82,4 @@ Once you have your pre-requisites ready, make sure you cover the following:
 - Keeper Vault PAM User Record is updated.
 
     <img src="images/rotated_password_success.png" width="350" alt="rotated_password_success">
+  

--- a/plugin_dev/cli.py
+++ b/plugin_dev/cli.py
@@ -290,12 +290,12 @@ def run_command(file, user_uid, plugin_config_uid, configuration_uid, fail, new_
                         Log.debug(f"custom field '{field['label']}' does not exist in user record, adding custom field")
                         user_record.dict["custom"].append(field)
 
-                Log.debug("updating the user record.")
-                user_record.set_standard_field_value("password", new_password)
-                getattr(user_record, "_update")()
-                sm.save(user_record)
+            Log.debug("updating the user record.")
+            user_record.set_standard_field_value("password", new_password)
+            getattr(user_record, "_update")()
+            sm.save(user_record)
 
-                print(f"{Fore.GREEN}Rotation was successful{Style.RESET_ALL}")
+            print(f"{Fore.GREEN}Rotation was successful{Style.RESET_ALL}")
 
         except Exception as err:
             Log.traceback(err)


### PR DESCRIPTION
* Removed certification field. Documentation shows using the SAML certification, which is not allowed. A cert can be used, but it needs to be a X.509, most likely attached to the admin user.
* Check the password policy to see if rollback is allowed. If has a history count, we cannot rollback.
* Return Cisco error message to user.

* Plugin tool would not save record unless return field was set. Fixed. Now saves without return field.